### PR TITLE
fix: In product add/edit page duplicate media and breadcrumb product title issue

### DIFF
--- a/src/app/(protected)/dashboard/general/products/[id]/page.tsx
+++ b/src/app/(protected)/dashboard/general/products/[id]/page.tsx
@@ -84,8 +84,7 @@ async function ProductReviewFetch({ params }: PageProps) {
                         Review &ldquo;{existingProduct.title}&rdquo;
                     </h1>
                     <p className="text-sm text-muted-foreground">
-                        Product submitted by {existingProduct.brand.name} (
-                        {existingProduct.brand.id})
+                        Product submitted by {existingProduct.brand.name}
                     </p>
                 </div>
 

--- a/src/app/(protected)/dashboard/layout.tsx
+++ b/src/app/(protected)/dashboard/layout.tsx
@@ -22,7 +22,7 @@ export default function Layout({ children }: LayoutProps) {
 
             <ShadSidebarInset className="max-w-full">
                 <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
-                    <div className="flex items-center gap-2 px-4">
+                    <div className="product-breadcrum flex items-center gap-2 px-4">
                         <SidebarTrigger className="-ml-1 hover:bg-transparent hover:text-foreground" />
 
                         <Separator

--- a/src/components/globals/forms/product-manage.tsx
+++ b/src/components/globals/forms/product-manage.tsx
@@ -104,9 +104,13 @@ export function ProductManageForm({
         ? product.media.map((m) => m.mediaItem!).filter(Boolean)
         : [];
 
+    const uniqueMedia = Array.from(
+        new Map(mediaItems.map((m) => [m.id, m])).values()
+    );
+
     const [isMediaSelectorOpen, setIsMediaSelectorOpen] = useState(false);
     const [selectedMedia, setSelectedMedia] =
-        useState<BrandMediaItem[]>(mediaItems);
+        useState<BrandMediaItem[]>(uniqueMedia);
     const [isSusCertificateSelectorOpen, setIsSusCertificateSelectorOpen] =
         useState(false);
     const [selectedSusCertificate, setSelectedSusCertificate] =
@@ -1547,16 +1551,20 @@ export function ProductManageForm({
                 accept="image/*, video/*"
                 multiple
                 onSelectionComplete={(items) => {
+                    const uniqueMedia = Array.from(
+                        new Map(items.map((m) => [m.id, m])).values()
+                    );
+
                     form.setValue(
                         "media",
-                        items.map((item, i) => ({
+                        uniqueMedia.map((item, i) => ({
                             id: item.id,
                             position: i + 1,
                         })),
                         { shouldDirty: true }
                     );
 
-                    setSelectedMedia(items);
+                    setSelectedMedia(uniqueMedia);
                 }}
             />
 

--- a/src/components/globals/layouts/sidebar/sidebar-inset.tsx
+++ b/src/components/globals/layouts/sidebar/sidebar-inset.tsx
@@ -17,6 +17,7 @@ import React from "react";
 export function SidebarInset({ className, ...props }: GenericProps) {
     const pathname = usePathname();
     const segments = pathname.split("/").filter(Boolean);
+    const productId = segments[segments.length - 1];
 
     const { data: brand } = trpc.general.brands.getBrand.useQuery(
         { id: segments[2] },
@@ -28,6 +29,16 @@ export function SidebarInset({ className, ...props }: GenericProps) {
         }
     );
 
+    const { data: product } = trpc.brands.products.getProduct.useQuery(
+        { productId },
+        {
+            enabled:
+                segments.length >= 6 &&
+                segments[3] === "products" &&
+                segments[4] === "p" &&
+                isValidUUID(productId),
+        }
+    );
     return (
         <Breadcrumb className={cn("", className)} {...props}>
             <BreadcrumbList>
@@ -40,7 +51,9 @@ export function SidebarInset({ className, ...props }: GenericProps) {
                         <BreadcrumbItem>
                             {index === segments.length - 1 ? (
                                 <BreadcrumbPage>
-                                    {convertValueToLabel(segment)}
+                                    {product
+                                        ? product.title
+                                        : convertValueToLabel(segment)}
                                 </BreadcrumbPage>
                             ) : (
                                 <BreadcrumbLink


### PR DESCRIPTION
**Description**

- From the product add/edit page while we add media displayed duplicate.
- `product-manage.tsx `need to fix where we make the selectedMedia to be unique any duplicates are removed.
- In porducts add/edit page the breadcrumb is not display the product title.
- In `sidebar-inset.tsx `get the product id and fetch details based on that display the title.

**Issues**

- _**[REN-6](https://trello.com/c/kg1koR2r/6-ren-6-brand-product-page-breadcrumb-is-loading-product-id-replace-it-with-the-product-name)**_
- _**[REN-4](https://trello.com/c/63lmbSjm/4-ren-4-product-add-edit-page-while-add-image-cant-remove-them-after-selecting)**_