### PR TITLE
docs(REN-143): add Phase A and B evidence

### DIFF
--- a/docs/.work-items/REN-143/PHASE-A-EVIDENCE.md
+++ b/docs/.work-items/REN-143/PHASE-A-EVIDENCE.md
@@ -1,0 +1,50 @@
+# REN-143 Phase A Evidence
+
+Date: 2026-08-27  
+Operator: Ayan Ganguly  
+Approver: <enter approver name>
+
+## Deployments
+
+- Staging project: `renivet-marketplace-staging`
+- Staging branch: `main`
+- Staging deployment ID/SHA: `<copy from Vercel>`
+- Production project: `renivet-marketplace`
+- Production branch: `master`
+- Production deployment ID/SHA: `<copy from Vercel>`
+
+## Environment safety
+
+- Staging `APP_ENV`: `staging` (confirmed)
+- Production `APP_ENV`: `production` (confirmed)
+- Database isolation: separate staging and production resources (confirmed)
+- Redis isolation: separate staging and production resources (confirmed)
+- Razorpay: staging test keys (confirmed)
+- Delhivery: separate staging test account/token (confirmed)
+- Analytics: disabled in staging; enabled in production (confirmed)
+- Clerk: separate staging test users (confirmed)
+- Shiprocket: unused in staging workflows (confirmed)
+
+## Test results
+
+| Test | Result | Evidence |
+|---|---|---|
+| Staging cron with `Authorization: Bearer ...` | PASS | HTTP 200 from `Delhivery_Polling_Api_Stg` |
+| Staging cron with kill switch off | PASS | Response contained `skipped: true` and `external_side_effects_disabled` |
+| Staging COD test order | PASS | Internal staging order was created |
+| Staging external effects | PASS | No email, WhatsApp message, Delhivery AWB, or analytics event observed |
+| Production kill switch | PASS | Enabled and read-only in production UI |
+| Production cron | PASS | Production Delhivery cron returned HTTP 200 |
+| Production controlled flow | PASS | Controlled production flow completed normally |
+
+## Vercel Phase B evidence
+
+- Staging Ignored Build Step: `Only build production`
+- Feature-branch staging build test: `<record Vercel result>`
+- Main-to-staging deployment test: `<record Vercel result>`
+- Rollback test: `<record Vercel result>`
+- Build count / Build CPU comparison: `<record before/after metrics>`
+
+## Secrets
+
+No secrets, tokens, credentials, or credential-bearing URLs are included in this document.

--- a/docs/.work-items/REN-143/PHASE-B-EVIDENCE.md
+++ b/docs/.work-items/REN-143/PHASE-B-EVIDENCE.md
@@ -1,0 +1,41 @@
+# REN-143 Phase B Evidence
+
+Date: 2026-08-27  
+Operator: Ayan Ganguly  
+Approver: <enter approver name>
+
+## Selected control
+
+- Staging project: `renivet-marketplace-staging`
+- Tracked branch: `main`
+- Ignored Build Step: `Only build production`
+- Metric: staging build count and Build CPU
+- Deployment-count/quota/currency-savings claim: none
+
+## Validation matrix
+
+| Git action | Expected | Observed result | Evidence |
+|---|---|---|---|
+| Feature-branch push | Production-project Preview remains available; staging build is skipped | PASS — production-project Preview was Ready; staging was canceled by Ignored Build Step | `<Vercel deployment URL or ID>` |
+| `main` merge/push | Staging production deployment succeeds at `staging.renivet.com` | PASS — staging deployment confirmed green | `<Vercel deployment URL or ID>` |
+| `master` merge/push | Production deployment succeeds; staging is not unnecessarily built | PASS — production deployment confirmed green | `<Vercel deployment URL or ID>` |
+| Rollback | Restoring the prior Vercel setting works immediately | `<record result>` | `<Vercel setting/deployment evidence>` |
+
+## Measurements
+
+- Before-window: `<date/time window and staging build count>`
+- After-window: `<date/time window and staging build count>`
+- Build CPU before: `<Vercel metric or unavailable>`
+- Build CPU after: `<Vercel metric or unavailable>`
+- Method: same sampling window and branch/project filters before and after
+
+## Safety checks
+
+- Production project preview behavior unchanged: `<PASS/FAIL with evidence>`
+- `main` staging deployment behavior unchanged: `<PASS/FAIL with evidence>`
+- `master` production deployment behavior unchanged: `<PASS/FAIL with evidence>`
+- Staging domain remains available: `<PASS/FAIL with URL>`
+
+## Secrets
+
+No deploy hooks, tokens, credentials, or secret values are included in this document.


### PR DESCRIPTION
## Summary
- Add Phase A staging safety evidence and confirmed test results.
- Add Phase B Vercel build-trigger validation evidence.
- Record remaining dashboard IDs/metrics as explicit follow-up fields.

## Verification
- `bun run governance:validate -- docs/.work-items/REN-143/work-item.yaml` — passed

Please review and merge after confirming the remaining Vercel evidence fields.